### PR TITLE
Implement Gui color name override

### DIFF
--- a/src/main/java/astrotibs/villagenames/mixins/Mixins.java
+++ b/src/main/java/astrotibs/villagenames/mixins/Mixins.java
@@ -9,7 +9,7 @@ public enum Mixins implements IMixins {
 
     MINECRAFT(Side.COMMON, "AccessorChunkProviderFlat", "AccessorChunkProviderGenerate", "AccessorChunkProviderHell",
             "AccessorEntityVillager", "AccessorEntityZombie", "AccessorStructureVillagePieces", "AccessorStructureVillagePiecesVillage",
-            "AccessorTextureAtlasSprite", "MixinChunkProviderFlat"),
+            "AccessorTextureAtlasSprite", "MixinChunkProviderFlat", "MixinGuiMerchant"),
 
     ;
 

--- a/src/main/java/astrotibs/villagenames/mixins/Mixins.java
+++ b/src/main/java/astrotibs/villagenames/mixins/Mixins.java
@@ -9,7 +9,8 @@ public enum Mixins implements IMixins {
 
     MINECRAFT(Side.COMMON, "AccessorChunkProviderFlat", "AccessorChunkProviderGenerate", "AccessorChunkProviderHell",
             "AccessorEntityVillager", "AccessorEntityZombie", "AccessorStructureVillagePieces", "AccessorStructureVillagePiecesVillage",
-            "AccessorTextureAtlasSprite", "MixinChunkProviderFlat", "MixinGuiMerchant"),
+            "AccessorTextureAtlasSprite", "MixinChunkProviderFlat"),
+    MINECRAFT_CLIENT(Side.CLIENT, "MixinGuiMerchant")
 
     ;
 

--- a/src/main/java/astrotibs/villagenames/mixins/early/MixinGuiMerchant.java
+++ b/src/main/java/astrotibs/villagenames/mixins/early/MixinGuiMerchant.java
@@ -1,45 +1,23 @@
 package astrotibs.villagenames.mixins.early;
 
 import net.minecraft.client.gui.GuiMerchant;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.IMerchant;
-import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.StatCollector;
+
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(GuiMerchant.class)
 public abstract class MixinGuiMerchant {
-
-    @Shadow
-    public abstract IMerchant func_147035_g();
-
     @ModifyArg(
-            method = "drawGuiContainerForegroundLayer",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/client/gui/FontRenderer;drawString(Ljava/lang/String;III)I",
-                    ordinal = 0
-            ),
-            index = 0
+        method = "drawGuiContainerForegroundLayer",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/FontRenderer;drawString(Ljava/lang/String;III)I",
+            ordinal = 0
+        )
     )
-    private String villagenames$replaceMerchantGuiTitle(String originalTitle) {
-        final IMerchant merchant = this.func_147035_g();
-        String merchantName = originalTitle;
-
-        if (merchant instanceof EntityLiving) {
-            final EntityLiving living = (EntityLiving) merchant;
-            if (living.hasCustomNameTag()) {
-                merchantName = living.getCustomNameTag();
-            } else {
-                merchantName = living.getCommandSenderName();
-            }
-        } else if (merchant instanceof Entity) {
-            merchantName = ((Entity) merchant).getCommandSenderName();
-        }
-
-        return StatCollector.translateToLocalFormatted("gui.Villager.name", merchantName);
+    private String villagenames$replaceTitleText(String original) {
+        return StatCollector.translateToLocalFormatted("gui.Villager.name", original);
     }
 }

--- a/src/main/java/astrotibs/villagenames/mixins/early/MixinGuiMerchant.java
+++ b/src/main/java/astrotibs/villagenames/mixins/early/MixinGuiMerchant.java
@@ -1,0 +1,45 @@
+package astrotibs.villagenames.mixins.early;
+
+import net.minecraft.client.gui.GuiMerchant;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.IMerchant;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.util.StatCollector;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(GuiMerchant.class)
+public abstract class MixinGuiMerchant {
+
+    @Shadow
+    public abstract IMerchant func_147035_g();
+
+    @ModifyArg(
+            method = "drawGuiContainerForegroundLayer",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/FontRenderer;drawString(Ljava/lang/String;III)I",
+                    ordinal = 0
+            ),
+            index = 0
+    )
+    private String villagenames$replaceMerchantGuiTitle(String originalTitle) {
+        final IMerchant merchant = this.func_147035_g();
+        String merchantName = originalTitle;
+
+        if (merchant instanceof EntityLiving) {
+            final EntityLiving living = (EntityLiving) merchant;
+            if (living.hasCustomNameTag()) {
+                merchantName = living.getCustomNameTag();
+            } else {
+                merchantName = living.getCommandSenderName();
+            }
+        } else if (merchant instanceof Entity) {
+            merchantName = ((Entity) merchant).getCommandSenderName();
+        }
+
+        return StatCollector.translateToLocalFormatted("gui.Villager.name", merchantName);
+    }
+}

--- a/src/main/resources/assets/villagenames/lang/en_US.lang
+++ b/src/main/resources/assets/villagenames/lang/en_US.lang
@@ -121,6 +121,7 @@ eggdisplay.VillageNames.guardian.elder.name=Elder Guardian
 
 # Villager careers/professions
 entity.Villager.farmer=Farmer
+gui.Villager.name=%s
 entity.Villager.fisherman=Fisherman
 entity.Villager.shepherd=Shepherd
 entity.Villager.fletcher=Fletcher


### PR DESCRIPTION
To change the color of the gui names with the resource packs. Fallback to normal

Example with `gui.Villager.name=§6%s`
<img width="725" height="520" alt="Name" src="https://github.com/user-attachments/assets/8ad0e551-86be-4107-8abb-84afe8248357" />
